### PR TITLE
Implementing redlines

### DIFF
--- a/app/src/main/res/drawable/touch_selector_today.xml
+++ b/app/src/main/res/drawable/touch_selector_today.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/sunshine_blue" />
+</selector>

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -28,31 +28,45 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/detail_day" />
+            android:id="@+id/detail_day"
+            android:fontFamily="sans-serif-condensed"
+            android:textSize="24sp"/>
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/detail_month_date" />
+            android:id="@+id/detail_month_date"
+            android:fontFamily="sans-serif-condensed"
+            android:textSize="16sp"
+            android:textColor="@color/dark_grey"/>
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:paddingTop="16dp">
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:paddingLeft="16dp">
 
             <LinearLayout
                 android:layout_width="0dp"
                 android:layout_weight="1"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:paddingLeft="32dp"
+                android:gravity="center_horizontal">
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:id="@+id/detail_high_temp" />
+                    android:id="@+id/detail_high_temp"
+                    android:fontFamily="sans-serif-light"
+                    android:textSize="96sp"/>
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:id="@+id/detail_low_temp" />
+                    android:id="@+id/detail_low_temp"
+                    android:fontFamily="sans-serif-light"
+                    android:textSize="48sp"
+                    android:textColor="@color/dark_grey"/>
 
             </LinearLayout>
 
@@ -70,7 +84,10 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:id="@+id/detail_forecast" />
+                    android:id="@+id/detail_forecast"
+                    android:fontFamily="sans-serif-condensed"
+                    android:textAppearance="@android:style/TextAppearance.Large"
+                    android:textColor="@color/dark_grey"/>
 
             </LinearLayout>
 
@@ -79,15 +96,24 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/detail_humidity" />
+            android:id="@+id/detail_humidity"
+            android:layout_marginTop="4dp"
+            android:fontFamily="sans-serif-light"
+            android:textAppearance="@android:style/TextAppearance.Large"/>
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/detail_wind" />
+            android:id="@+id/detail_wind"
+            android:layout_marginTop="4dp"
+            android:fontFamily="sans-serif-light"
+            android:textAppearance="@android:style/TextAppearance.Large" />
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/detail_pressure" />
+            android:id="@+id/detail_pressure"
+            android:layout_marginTop="4dp"
+            android:fontFamily="sans-serif-light"
+            android:textAppearance="@android:style/TextAppearance.Large"/>
 
         <!--<TextView-->
         <!--android:layout_width="wrap_content"-->

--- a/app/src/main/res/layout/fragment_detail_land_and_2pane.xml
+++ b/app/src/main/res/layout/fragment_detail_land_and_2pane.xml
@@ -14,18 +14,25 @@
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:minWidth="56dp"
             android:orientation="vertical">
 
             <!-- Header: Day, Date -->
             <TextView
                 android:id="@+id/detail_day"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-condensed"
+                android:minWidth="120dp"
+                android:textSize="24sp"/>
 
             <TextView
                 android:id="@+id/detail_month_date"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-condensed"
+                android:textSize="20sp"
+                android:textColor="@color/dark_grey"/>
 
         </LinearLayout>
 
@@ -37,37 +44,50 @@
             android:orientation="vertical">
 
             <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:id="@+id/detail_high_temp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
-
+                android:fontFamily="sans-serif-light"
+                android:textSize="96sp"/>
             <TextView
-                android:id="@+id/detail_low_temp"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:id="@+id/detail_low_temp"
+                android:fontFamily="sans-serif-light"
+                android:textSize="48sp"
+                android:textColor="@color/dark_grey"/>
 
             <!-- Humidity, wind, pressure -->
             <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:id="@+id/detail_humidity"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
-
+                android:layout_marginTop="10dp"
+                android:fontFamily="sans-serif-light"
+                android:textAppearance="@android:style/TextAppearance.Large"/>
             <TextView
-                android:id="@+id/detail_pressure"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
-
-            <TextView
+                android:layout_height="wrap_content"
                 android:id="@+id/detail_wind"
+                android:layout_marginTop="4dp"
+                android:fontFamily="sans-serif-light"
+                android:textAppearance="@android:style/TextAppearance.Large" />
+            <TextView
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:id="@+id/detail_pressure"
+                android:layout_marginTop="4dp"
+                android:fontFamily="sans-serif-light"
+                android:textAppearance="@android:style/TextAppearance.Large"/>
+
         </LinearLayout>
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:layout_marginLeft="16dp" >
 
             <ImageView
                 android:id="@+id/detail_icon"
@@ -77,7 +97,10 @@
             <TextView
                 android:id="@+id/detail_forecast"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-condensed"
+                android:textAppearance="@android:style/TextAppearance.Large"
+                android:textColor="@color/dark_grey"/>
         </LinearLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -2,10 +2,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
     tools:context="com.example.pratu16x7.sunshinefromscratch.ForecastFragment">
 
     <ListView
@@ -13,6 +9,6 @@
         android:layout_height="match_parent"
         android:id="@+id/listview_forecast"
         style="@style/ForecastListStyle"
-        />
+        android:divider="@null"/>
 
 </FrameLayout>

--- a/app/src/main/res/layout/list_item_forecast.xml
+++ b/app/src/main/res/layout/list_item_forecast.xml
@@ -4,38 +4,49 @@
     android:gravity="center_vertical"
     android:minHeight="?android:attr/listPreferredItemHeight"
     android:orientation="horizontal"
-    android:background="@drawable/touch_selector"
-    android:padding="16dp">
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/list_item_icon"/>
+    android:background="@drawable/touch_selector">
+    <FrameLayout
+        android:layout_width="60dp"
+        android:layout_height="match_parent">
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/list_item_icon"
+            android:layout_gravity="center" />
+    </FrameLayout>
     <LinearLayout android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:orientation="vertical"
-        android:paddingLeft="16dp">
-        <TextView
-            android:layout_width="wrap_content" android:layout_height="wrap_content"
-            android:id="@+id/list_item_date_textview"
-            android:textSize="20sp">
-        </TextView>
-        <TextView
-            android:layout_width="wrap_content" android:layout_height="wrap_content"
-            android:id="@+id/list_item_forecast_textview">
-        </TextView>
-    </LinearLayout>
-    <LinearLayout android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_weight="7"
         android:orientation="vertical">
         <TextView
             android:layout_width="wrap_content" android:layout_height="wrap_content"
-            android:id="@+id/list_item_high_textview"
-            android:textSize="20sp">
+            android:id="@+id/list_item_date_textview"
+            android:fontFamily="sans-serif-condensed"
+            android:textAppearance="@android:style/TextAppearance.Large">
         </TextView>
         <TextView
             android:layout_width="wrap_content" android:layout_height="wrap_content"
-            android:id="@+id/list_item_low_textview">
+            android:id="@+id/list_item_forecast_textview"
+            android:fontFamily="sans-serif-condensed"
+            android:textAppearance="@android:style/TextAppearance.Small">
+        </TextView>
+    </LinearLayout>
+    <LinearLayout android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="5"
+        android:orientation="vertical"
+        android:gravity="center_horizontal">
+        <TextView
+            android:layout_width="wrap_content" android:layout_height="wrap_content"
+            android:id="@+id/list_item_high_textview"
+            android:fontFamily="sans-serif-condensed"
+            android:textAppearance="@android:style/TextAppearance.Large">
+        </TextView>
+        <TextView
+            android:layout_width="wrap_content" android:layout_height="wrap_content"
+            android:id="@+id/list_item_low_textview"
+            android:fontFamily="sans-serif-condensed"
+            android:textAppearance="@android:style/TextAppearance.Small">
         </TextView>
     </LinearLayout>
 

--- a/app/src/main/res/layout/list_item_forecast_today.xml
+++ b/app/src/main/res/layout/list_item_forecast_today.xml
@@ -2,47 +2,62 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical"
     android:minHeight="@dimen/abc_action_bar_stacked_max_height"
-    android:padding="20dp"
-    android:background="@drawable/touch_selector" >
+    android:paddingTop="16dp"
+    android:paddingBottom="16dp"
+    android:paddingRight="16dp"
+    android:background="@drawable/touch_selector_today" >
 
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
+        android:layout_weight="7"
         android:orientation="vertical"
-        android:gravity="center_horizontal"
-        >
+        android:layout_marginLeft="60dp">
         <TextView
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/list_item_date_textview"/>
+            android:id="@+id/list_item_date_textview"
+            android:fontFamily="sans-serif-condensed"
+            android:textAppearance="@android:style/TextAppearance.Large"
+            android:textColor="@color/white"/>
         <TextView
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/list_item_high_textview"/>
+            android:id="@+id/list_item_high_textview"
+            android:fontFamily="sans-serif-light"
+            android:textSize="72sp"
+            android:textColor="@color/white"/>
         <TextView
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/list_item_low_textview"/>
+            android:id="@+id/list_item_low_textview"
+            android:fontFamily="sans-serif-light"
+            android:textSize="36sp"
+            android:textColor="@color/white"
+            android:paddingLeft="8dp"/>
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
+        android:layout_height="match_parent"
+        android:layout_weight="5"
         android:orientation="vertical"
-        android:gravity="center_horizontal"
-        >
+        android:gravity="bottom|center_horizontal">
         <ImageView
-            android:id="@+id/list_item_icon"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            android:id="@+id/list_item_icon"
+            android:layout_gravity="center_horizontal"/>
+
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:id="@+id/list_item_forecast_textview"/>
+            android:id="@+id/list_item_forecast_textview"
+            android:fontFamily="sans-serif-condensed"
+            android:textAppearance="@android:style/TextAppearance.Large"
+            android:layout_gravity="center_horizontal"
+            android:textColor="@color/white"/>
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="grey">#cccccc</color>
+    <color name="dark_grey">#646464</color>
     <color name="sunshine_light_blue">#ff64c2f4</color>
     <color name="sunshine_blue">#ff1ca8f4</color>
     <color name="sunshine_dark_blue">#0288D1</color>
+    <color name="white">#FFFFFF</color>
 </resources>


### PR DESCRIPTION
As learned before, mdpi scale is the baseline. Can keep the icons in a
Frame(with set width and height) and set wrap content on their
imageView. Units sp(scaled pixels) for text lets us scale with the
device font size. MinWidth useful for assurance of proper display.
Typefaces, default sizes and colors. Again new drawable to set today
background.

Phone developer options have a show layout bounds option! That’s so
cool :D